### PR TITLE
print all error messages to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a fork of the original zeo++ code (version 0.3.0) with 
 For a list of changes, see the [CHANGELOG.md](./CHANGELOG.md).
 
 WWW: http://www.carboncapturematerials.org/Zeo++/
+
 Email: mharanczyk@lbl.gov (Zeo++) and chr@alum.mit.edu (Voro++)
 
 ## About
@@ -41,8 +42,8 @@ can be carried out using GNU Make.
 
 Clone the git repository
 ```
-git clone https://github.com/lsmo-epfl/zeoplusplus
-cd zeoplusplus
+git clone https://github.com/lsmo-epfl/zeopp-lsmo
+cd zeopp-lsmo
 ```
 
 Download Eigen library v3.2.7 (if not already installed)

--- a/voro++/config.mk
+++ b/voro++/config.mk
@@ -11,7 +11,7 @@
 #CXX=g++
 
 # Flags for the C++ compiler
-CFLAGS=-Wall -ansi -pedantic -O3
+CFLAGS+=-Wall -ansi -pedantic -O3
 
 # Relative include and library paths for compilation of the examples
 E_INC=-I../../src

--- a/zeo++/area_and_volume.cc
+++ b/zeo++/area_and_volume.cc
@@ -296,7 +296,7 @@ double calcAV(ATOM_NETWORK *atmnet, ATOM_NETWORK *orgatmnet, bool highAccuracy,
       count_inaxs++;
       pair<int, int> CoP = accessAnalysis.lastChannelOrPocket();
       if (CoP.first != -1) {
-        cout
+        cerr
             << "Error: CoP.first!=-1 in pocket, consult source code provider\n";
       } else {
         count_inPocket[CoP.second]++;
@@ -315,7 +315,7 @@ double calcAV(ATOM_NETWORK *atmnet, ATOM_NETWORK *orgatmnet, bool highAccuracy,
       count++;
       pair<int, int> CoP = accessAnalysis.lastChannelOrPocket();
       if (CoP.second != -1) {
-        cout << "Error: CoP.second!=-1 in channel, consult source code "
+        cerr << "Error: CoP.second!=-1 in channel, consult source code "
                 "provider\n";
       } else {
         count_inChannel[CoP.first]++;
@@ -830,7 +830,7 @@ double NEWcalcAV(MATERIAL *Mat, double r_probe, int numSamples,
       count_inaxs++;
       pair<int, int> CoP = Mat->accessAnalysis.lastChannelOrPocket();
       if (CoP.first != -1) {
-        cout
+        cerr
             << "Error: CoP.first!=-1 in pocket, consult source code provider\n";
       } else {
         Mat->AVcount_inPocket[CoP.second]++;
@@ -850,7 +850,7 @@ double NEWcalcAV(MATERIAL *Mat, double r_probe, int numSamples,
       count++;
       pair<int, int> CoP = Mat->accessAnalysis.lastChannelOrPocket();
       if (CoP.second != -1) {
-        cout << "Error: CoP.second!=-1 in channel, consult source code "
+        cerr << "Error: CoP.second!=-1 in channel, consult source code "
                 "provider\n";
       } else {
         Mat->AVcount_inChannel[CoP.first]++;
@@ -2020,7 +2020,7 @@ double calcASA(ATOM_NETWORK *hiaccatmnet, ATOM_NETWORK *orgatmnet,
           inaxsPoints.push_back(coords);
           pair<int, int> CoP = accessAnalysis.lastChannelOrPocket();
           if (CoP.first != -1) {
-            cout << "Error: CoP.first!=-1 in pocket, consult source code "
+            cerr << "Error: CoP.first!=-1 in pocket, consult source code "
                     "provider\n";
           } else {
             count_inPocket[CoP.second]++;
@@ -2031,7 +2031,7 @@ double calcASA(ATOM_NETWORK *hiaccatmnet, ATOM_NETWORK *orgatmnet,
           count++;
           pair<int, int> CoP = accessAnalysis.lastChannelOrPocket();
           if (CoP.second != -1) {
-            cout << "Error: CoP.second!=-1 in channel, consult source code "
+            cerr << "Error: CoP.second!=-1 in channel, consult source code "
                     "provider\n";
           } else {
             count_inChannel[CoP.first]++;
@@ -2299,7 +2299,7 @@ double NEWcalcASA(MATERIAL *Mat, double r_probe, int sampleDensity) {
           Mat->ASAinaxsPoints.push_back(coords);
           pair<int, int> CoP = Mat->accessAnalysis.lastChannelOrPocket();
           if (CoP.first != -1) {
-            cout << "Error: CoP.first!=-1 in pocket, consult source code "
+            cerr << "Error: CoP.first!=-1 in pocket, consult source code "
                     "provider\n";
           } else {
             count_inPocket[CoP.second]++;
@@ -2310,7 +2310,7 @@ double NEWcalcASA(MATERIAL *Mat, double r_probe, int sampleDensity) {
           count++;
           pair<int, int> CoP = Mat->accessAnalysis.lastChannelOrPocket();
           if (CoP.second != -1) {
-            cout << "Error: CoP.second!=-1 in channel, consult source code "
+            cerr << "Error: CoP.second!=-1 in channel, consult source code "
                     "provider\n";
           } else {
             count_inChannel[CoP.first]++;

--- a/zeo++/main.cc
+++ b/zeo++/main.cc
@@ -447,6 +447,7 @@ int main(int argc, char *argv[]) {
             vector<CHANNEL> channels;
             if (command.size() < 2 || command.size() > 3) {
               fprintf(
+                  stderr,
                   "Error: -holo option accepts 1 (probe radius) or 2 (probe "
                   "radius and then bin directory) arguments but %d arguments "
                   "were supplied.\n",
@@ -776,13 +777,15 @@ int main(int argc, char *argv[]) {
                           // the fraction of accessible volume which is within
                           // this distance range away from any atom CENTRE
               fprintf(
+                  stderr,
                   "Error: -vol option accepts between 3 and 6 arguments 1 but "
                   "%d arguments were supplied.\n",
                   (int)(command.size() - 1));
+              fprintf(stderr,
+                      "Note:\t-vol chan_radius probe_radius num_samples "
+                      "[outputfile_vol]\n");
               fprintf(
-                  "Note:\t-vol chan_radius probe_radius num_samples "
-                  "[outputfile_vol]\n");
-              fprintf(
+                  stderr,
                   "or:\t-vol chan_radius probe_radius num_samples "
                   "low_distance_range high_distance_range [outputfile_vol]\n");
               printf("Exiting...\n");
@@ -805,6 +808,7 @@ int main(int argc, char *argv[]) {
             int numSamples = int(strtod(command[3].data(), NULL));
             if (numSamples < 0) {
               fprintf(
+                  stderr,
                   "ERROR: cannot call -vol flag with negative numSamples (arg "
                   "was: %d)\n",
                   numSamples);
@@ -1377,6 +1381,7 @@ int main(int argc, char *argv[]) {
           else if (command[0].compare("-visVoro") == 0) {
             if (command.size() != 2 && command.size() != 5) {
               fprintf(
+                  stderr,
                   "Error: -visVoro option accepts 1 (probe radius) or 4 (probe "
                   "radius and then a, b and c shifts for illustrating "
                   "accessible part of network) arguments but %d arguments were "
@@ -1408,6 +1413,7 @@ int main(int argc, char *argv[]) {
           else if (command[0].compare("-sphericalSubstructures") == 0) {
             if (command.size() != 3 && command.size() != 4) {
               fprintf(
+                  stderr,
                   "Error: -sphericalSubstructures option accepts 2 or 3 "
                   "(probe_radius, sphere_radius, [element_type]) argument but "
                   "%d arguments were supplied.\n",
@@ -1468,6 +1474,7 @@ int main(int argc, char *argv[]) {
           else if (command[0].compare("-cellmulti") == 0) {
             if (command.size() != 2) {
               fprintf(
+                  stderr,
                   "Error: -cellmulti option accepts 1 (sphere radius) argument "
                   "but %d arguments were supplied.\n",
                   (int)(command.size() - 1));

--- a/zeo++/main.cc
+++ b/zeo++/main.cc
@@ -446,7 +446,7 @@ int main(int argc, char *argv[]) {
             vector<bool> accessInfo;
             vector<CHANNEL> channels;
             if (command.size() < 2 || command.size() > 3) {
-              printf(
+              fprintf(
                   "Error: -holo option accepts 1 (probe radius) or 2 (probe "
                   "radius and then bin directory) arguments but %d arguments "
                   "were supplied.\n",
@@ -775,14 +775,14 @@ int main(int argc, char *argv[]) {
                     7) {  // running with additional distance arguments tell you
                           // the fraction of accessible volume which is within
                           // this distance range away from any atom CENTRE
-              printf(
+              fprintf(
                   "Error: -vol option accepts between 3 and 6 arguments 1 but "
                   "%d arguments were supplied.\n",
                   (int)(command.size() - 1));
-              printf(
+              fprintf(
                   "Note:\t-vol chan_radius probe_radius num_samples "
                   "[outputfile_vol]\n");
-              printf(
+              fprintf(
                   "or:\t-vol chan_radius probe_radius num_samples "
                   "low_distance_range high_distance_range [outputfile_vol]\n");
               printf("Exiting...\n");
@@ -804,7 +804,7 @@ int main(int argc, char *argv[]) {
             double probe_radius = strtod(command[2].data(), NULL);
             int numSamples = int(strtod(command[3].data(), NULL));
             if (numSamples < 0) {
-              printf(
+              fprintf(
                   "ERROR: cannot call -vol flag with negative numSamples (arg "
                   "was: %d)\n",
                   numSamples);
@@ -1376,7 +1376,7 @@ int main(int argc, char *argv[]) {
           // if specified with shift - xyz and vtk output files generated)
           else if (command[0].compare("-visVoro") == 0) {
             if (command.size() != 2 && command.size() != 5) {
-              printf(
+              fprintf(
                   "Error: -visVoro option accepts 1 (probe radius) or 4 (probe "
                   "radius and then a, b and c shifts for illustrating "
                   "accessible part of network) arguments but %d arguments were "
@@ -1407,7 +1407,7 @@ int main(int argc, char *argv[]) {
           // type
           else if (command[0].compare("-sphericalSubstructures") == 0) {
             if (command.size() != 3 && command.size() != 4) {
-              printf(
+              fprintf(
                   "Error: -sphericalSubstructures option accepts 2 or 3 "
                   "(probe_radius, sphere_radius, [element_type]) argument but "
                   "%d arguments were supplied.\n",
@@ -1467,7 +1467,7 @@ int main(int argc, char *argv[]) {
           // radius overlaps with itself periodically
           else if (command[0].compare("-cellmulti") == 0) {
             if (command.size() != 2) {
-              printf(
+              fprintf(
                   "Error: -cellmulti option accepts 1 (sphere radius) argument "
                   "but %d arguments were supplied.\n",
                   (int)(command.size() - 1));

--- a/zeo++/network.cc
+++ b/zeo++/network.cc
@@ -328,10 +328,10 @@ bool storeVoronoiNetwork(c_option &con, ATOM_NETWORK *atmnet,
   double error_percent_tolerance =
       0.001;  // former (before Voro++ fit default = 0.1;
   if (error_percent > error_percent_tolerance) {
-    fprintf(
-        "Error: Voronoi volume check failed (%.3f%% error, > %.3f%% "
-        "tolerance).\nExiting...\n",
-        error_percent, error_percent_tolerance);
+    fprintf(stderr,
+            "Error: Voronoi volume check failed (%.3f%% error, > %.3f%% "
+            "tolerance).\nExiting...\n",
+            error_percent, error_percent_tolerance);
     return false;
     //      exit(1);
   }

--- a/zeo++/network.cc
+++ b/zeo++/network.cc
@@ -328,7 +328,7 @@ bool storeVoronoiNetwork(c_option &con, ATOM_NETWORK *atmnet,
   double error_percent_tolerance =
       0.001;  // former (before Voro++ fit default = 0.1;
   if (error_percent > error_percent_tolerance) {
-    printf(
+    fprintf(
         "Error: Voronoi volume check failed (%.3f%% error, > %.3f%% "
         "tolerance).\nExiting...\n",
         error_percent, error_percent_tolerance);

--- a/zeo++/networkio.cc
+++ b/zeo++/networkio.cc
@@ -296,7 +296,7 @@ bool readCIFFile(char *filename, ATOM_NETWORK *cell, bool radial) {
       // no symmetry provided
       if (symmetry_Int_Table_number >= 0 && symmetry_Int_Table_number != 1) {
         // read a symmetry table number, but it was not 1
-        printf(
+        fprintf(
             "ERROR:\n\tcif file provided no symmetry operations; however, a "
             "symmetry_Int_Tables_Number of %d was provided,\n\tindicating "
             "symmetry which is not 'P 1' (no symmetry operations);\n\tcannot "
@@ -464,7 +464,7 @@ bool readARCFile(char *filename, ATOM_NETWORK *cell, bool radial) {
           }
         }
       } else {
-        printf(
+        fprintf(
             "ERROR: finished parsing ARC file before finding geometry "
             "section\n");
         //        exit(EXIT_FAILURE);
@@ -514,7 +514,7 @@ bool readARCFile(char *filename, ATOM_NETWORK *cell, bool radial) {
           found_atoms = 0;  // if we can't read all 8 fields, we have,
                             // presumably, reached the unit cell params
       } else {
-        printf(
+        fprintf(
             "ERROR: finished parsing ARC file before finding unit cell info\n");
         //        exit(EXIT_FAILURE);
         fclose(input);
@@ -543,7 +543,7 @@ bool readARCFile(char *filename, ATOM_NETWORK *cell, bool radial) {
           int status = sscanf(this_line, "%s %lf %s %lf %s %lf %s", element, &x,
                               str1, &y, str2, &z, str3);
           if (status != 7) {  // didn't read exactly 7 fields
-            printf("ERROR: could not read exactly three unit cell vectors\n");
+            fprintf("ERROR: could not read exactly three unit cell vectors\n");
             //            exit(EXIT_FAILURE);
             fclose(input);
             return false;
@@ -1827,7 +1827,7 @@ bool writeToMOPAC(char *filename, ATOM_NETWORK *cell, bool is_supercell) {
   fstream output;
   output.open(filename, fstream::out);
   if (!output.is_open()) {
-    cout << "Error: Failed to open .mop output file " << filename << endl;
+    cerr << "Error: Failed to open .mop output file " << filename << endl;
     // cout << "Exiting ..." << "\n";
     // exit(1);
     return false;

--- a/zeo++/networkio.cc
+++ b/zeo++/networkio.cc
@@ -297,6 +297,7 @@ bool readCIFFile(char *filename, ATOM_NETWORK *cell, bool radial) {
       if (symmetry_Int_Table_number >= 0 && symmetry_Int_Table_number != 1) {
         // read a symmetry table number, but it was not 1
         fprintf(
+            stderr,
             "ERROR:\n\tcif file provided no symmetry operations; however, a "
             "symmetry_Int_Tables_Number of %d was provided,\n\tindicating "
             "symmetry which is not 'P 1' (no symmetry operations);\n\tcannot "
@@ -464,9 +465,9 @@ bool readARCFile(char *filename, ATOM_NETWORK *cell, bool radial) {
           }
         }
       } else {
-        fprintf(
-            "ERROR: finished parsing ARC file before finding geometry "
-            "section\n");
+        fprintf(stderr,
+                "ERROR: finished parsing ARC file before finding geometry "
+                "section\n");
         //        exit(EXIT_FAILURE);
         fclose(input);
         return false;
@@ -515,6 +516,7 @@ bool readARCFile(char *filename, ATOM_NETWORK *cell, bool radial) {
                             // presumably, reached the unit cell params
       } else {
         fprintf(
+            stderr,
             "ERROR: finished parsing ARC file before finding unit cell info\n");
         //        exit(EXIT_FAILURE);
         fclose(input);
@@ -543,7 +545,8 @@ bool readARCFile(char *filename, ATOM_NETWORK *cell, bool radial) {
           int status = sscanf(this_line, "%s %lf %s %lf %s %lf %s", element, &x,
                               str1, &y, str2, &z, str3);
           if (status != 7) {  // didn't read exactly 7 fields
-            fprintf("ERROR: could not read exactly three unit cell vectors\n");
+            fprintf(stderr,
+                    "ERROR: could not read exactly three unit cell vectors\n");
             //            exit(EXIT_FAILURE);
             fclose(input);
             return false;

--- a/zeo++/voronoicell.cc
+++ b/zeo++/voronoicell.cc
@@ -459,7 +459,7 @@ void writeZeoVisFile(char *filename, vector<VOR_CELL> *cells,
   fstream output;
   output.open(filename, fstream::out);
   if (!output.is_open()) {
-    cout << "Error: Failed to open output file for ZeoVis settings" << filename;
+    cerr << "Error: Failed to open output file for ZeoVis settings" << filename;
     cout << "Exiting ..."
          << "\n";
     exit(1);
@@ -492,7 +492,7 @@ void writeSpecialZeoVisFile(char *filename, vector<VOR_CELL> *cells,
   fstream output;
   output.open(filename, fstream::out);
   if (!output.is_open()) {
-    cout << "Error: Failed to open output file for ZeoVis settings" << filename;
+    cerr << "Error: Failed to open output file for ZeoVis settings" << filename;
     cout << "Exiting ..."
          << "\n";
     exit(1);

--- a/zeo++/zeojobs.h
+++ b/zeo++/zeojobs.h
@@ -508,7 +508,7 @@ class zeoJob {
         output.close();
       } else if (command[0].compare("-visVoro") == 0) {  // for visualization
         if (command.size() != 1 && command.size() != 4) {
-          printf(
+          fprintf(
               "Error: -visVoro option accepts 0 or 3 (a, b and c shifts for "
               "illustrating accessible part of network) arguments but %d "
               "arguments were supplied.\n",
@@ -535,7 +535,7 @@ class zeoJob {
         vector<bool> accessInfo;
         vector<CHANNEL> channels;
         if (command.size() < 1 || command.size() > 2) {
-          printf(
+          fprintf(
               "Error: -holo option accepts no or 1 (bin directory) argument "
               "but %d arguments were supplied.\n",
               (int)(command.size() - 1));
@@ -877,7 +877,7 @@ class zeoJob {
       // a material
       else if (command[0].compare("-findTetrahedra") == 0) {
         if (command.size() != 2) {
-          printf(
+          fprintf(
               "Error: -findTetrahedra option accepts 1 (element type) argument "
               "but %d arguments were supplied.\n",
               (int)(command.size() - 1));
@@ -901,7 +901,7 @@ class zeoJob {
       // radius overlaps with itself periodically
       else if (command[0].compare("-cellmulti") == 0) {
         if (command.size() != 2) {
-          printf(
+          fprintf(
               "Error: -cellmulti option accepts 1 (sphere radius) argument but "
               "%d arguments were supplied.\n",
               (int)(command.size() - 1));

--- a/zeo++/zeojobs.h
+++ b/zeo++/zeojobs.h
@@ -509,6 +509,7 @@ class zeoJob {
       } else if (command[0].compare("-visVoro") == 0) {  // for visualization
         if (command.size() != 1 && command.size() != 4) {
           fprintf(
+              stderr,
               "Error: -visVoro option accepts 0 or 3 (a, b and c shifts for "
               "illustrating accessible part of network) arguments but %d "
               "arguments were supplied.\n",
@@ -536,6 +537,7 @@ class zeoJob {
         vector<CHANNEL> channels;
         if (command.size() < 1 || command.size() > 2) {
           fprintf(
+              stderr,
               "Error: -holo option accepts no or 1 (bin directory) argument "
               "but %d arguments were supplied.\n",
               (int)(command.size() - 1));
@@ -878,6 +880,7 @@ class zeoJob {
       else if (command[0].compare("-findTetrahedra") == 0) {
         if (command.size() != 2) {
           fprintf(
+              stderr,
               "Error: -findTetrahedra option accepts 1 (element type) argument "
               "but %d arguments were supplied.\n",
               (int)(command.size() - 1));
@@ -902,6 +905,7 @@ class zeoJob {
       else if (command[0].compare("-cellmulti") == 0) {
         if (command.size() != 2) {
           fprintf(
+              stderr,
               "Error: -cellmulti option accepts 1 (sphere radius) argument but "
               "%d arguments were supplied.\n",
               (int)(command.size() - 1));


### PR DESCRIPTION
fix #6 

Some error messages were printed to stdout instead of stderr.
Since stdout is buffered by default, these error messages can be lost,
e.g. when running zeo++ through slurm.